### PR TITLE
Add installed library name for Ubuntu 20.04.

### DIFF
--- a/lib/ffi-portaudio/api.rb
+++ b/lib/ffi-portaudio/api.rb
@@ -1,7 +1,7 @@
 module FFI::PortAudio::API
   extend FFI::Library
 
-  ffi_lib 'portaudio'
+  ffi_lib ['portaudio', 'libportaudio.so.2']
 
   callback :PaStreamCallback, [:pointer, :pointer, :ulong, PaStreamCallbackTimeInfo.in, :ulong, :pointer], :PaStreamCallbackResult
   callback :PaStreamFinishedCallback, [:pointer], :void


### PR DESCRIPTION
Enable use of this gem on Ubuntu 20.04 without needing to install the Port Audio development package. (Other versions of Ubuntu, and other distros might need different library names.)

See https://github.com/ffi/ffi/wiki/Loading-Libraries#linux-packages for details.