### PR TITLE
Add support for Windows.

### DIFF
--- a/ffi-portaudio.gemspec
+++ b/ffi-portaudio.gemspec
@@ -30,5 +30,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
   s.require_paths = ["lib"]
   s.add_dependency "ffi"
+
+  s.metadata['msys2_mingw_dependencies'] = 'portaudio'
 end
 

--- a/lib/ffi-portaudio/api.rb
+++ b/lib/ffi-portaudio/api.rb
@@ -1,7 +1,7 @@
 module FFI::PortAudio::API
   extend FFI::Library
 
-  ffi_lib ['portaudio', 'libportaudio.so.2']
+  ffi_lib ['portaudio', 'libportaudio.so.2', 'libportaudio-2']
 
   callback :PaStreamCallback, [:pointer, :pointer, :ulong, PaStreamCallbackTimeInfo.in, :ulong, :pointer], :PaStreamCallbackResult
   callback :PaStreamFinishedCallback, [:pointer], :void

--- a/lib/ffi-portaudio/api.rb
+++ b/lib/ffi-portaudio/api.rb
@@ -1,7 +1,7 @@
 module FFI::PortAudio::API
   extend FFI::Library
 
-  ffi_lib ['portaudio', 'libportaudio.so.2', 'libportaudio-2']
+  ffi_lib ['portaudio', 'libportaudio.so.2', 'libportaudio', 'libportaudio-2']
 
   callback :PaStreamCallback, [:pointer, :pointer, :ulong, PaStreamCallbackTimeInfo.in, :ulong, :pointer], :PaStreamCallbackResult
   callback :PaStreamFinishedCallback, [:pointer], :void


### PR DESCRIPTION
Added a library for Windows to ffi_lib. 
In a Windows RubyInstaller2 environment, fortunately the portaudio librarie is available through the MSYS2 repository.

install `mingw-w64-x86_64-portaudio` package.
```
>ridk exec pacman -S mingw-w64-x86_64-portaudio
```

[The ridk tool](https://github.com/oneclick/rubyinstaller2/wiki/The-ridk-tool) is a helper tool to manage the runtime environment of RubyInstaller2. It can be used in cmd.