### PR TITLE
Add CI for macOS and Ubuntu

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,34 @@
+name: build
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    name: ${{ matrix.os }} Ruby ${{ matrix.ruby }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:   [ 'ubuntu', 'macos']
+        ruby: [ '2.6', '2.7', '3.0' ]
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - name: Set up portaudio (ubuntu)
+        if: ${{ matrix.os == 'ubuntu' }}
+        run: |
+          sudo apt update -y
+          sudo apt install -y -V portaudio19-dev
+      - name: Set up portaudio (macos)
+        if: ${{ matrix.os == 'macos' }}
+        run: |
+          brew install portaudio
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Rake test
+        run: bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,7 @@ source "http://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.0", group: :development
+group :development do
+  gem "rake", "~> 12.0"
+  gem "test-unit"
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,4 @@
+require 'bundler/setup'
+Bundler.require(:development)
+require 'test/unit'
+require 'ffi-portaudio'

--- a/test/test_ffi-portaudio.rb
+++ b/test/test_ffi-portaudio.rb
@@ -1,0 +1,11 @@
+require_relative 'helper'
+
+class TestFFIPortaudio < Test::Unit::TestCase
+  test :it_has_a_version_number do
+    assert_kind_of String, ::FFI::PortAudio::VERSION
+  end
+
+  test :it_get_portaudio_version_number do
+    assert_kind_of String, ::FFI::PortAudio::API.Pa_GetVersionText
+  end
+end


### PR DESCRIPTION
Hi!

Thank you for releasing the new Gem.
I added tests for macOS and Ubuntu. Since test-unit was used in the previous [tests](https://github.com/nanki/ffi-portaudio/blob/v0.1.2/test/helper.rb), I followed it again this time. 
Feel free to edit it. It would be great if you could merge them.

Motivation:
My motivation is to use ffi-portaudio in my Gem ([LibUI](https://github.com/kojix2/LibUI) and [GR.rb](https://github.com/kojix2/GR.rb)) examples.
I want these gems to be cross-platform, so I want to make sure that ffi-portaudio works in multiple environments.

Thank you.

Translated with www.DeepL.com/Translator (free version)